### PR TITLE
CLI for just running tests on a formatted swagger file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,17 @@ var tests = swaggestTest.parse(spec);
 
 The resulting 'tests' will be an Object with keys for each route. Each route then also has keys for each method. Inside each method is a list containing the tests. These tests can be run as follows:
 ```javascript
-var request = require('request');
+var preq = require('preq');
 it(test.description, function() {
-  return request[test.request.method]({
+  return preq[test.request.method]({
       uri: test.request.uri,
       query: test.request.query,
       headers: test.request.headers,
       body: test.request.body
-    }, function(err, response) {
+    })
+    .then(function (response) {
+      swaggestTest.assert(test.response, response);
+    }, function (response) {
       swaggestTest.assert(test.response, response);
     });
 });
@@ -62,7 +65,7 @@ it(test.description, function() {
 All together, we recommend running something like this in a tests.json:
 ```javascript
 var fs = require('fs')
-  , request = require('request');
+  , preq = require('preq');
 var swaggerTest = require('../lib/swaggest-test');
 
 describe('test api calls', function () {
@@ -79,7 +82,10 @@ describe('test api calls', function () {
               uri: test.request.uri,
               query: test.request.query,
               body: test.request.body,
-              headers: test.request.headers}, function (err, result) {
+              headers: test.request.headers})
+              .then(function (response) {
+                swaggestTest.assert(test.response, response);
+              }, function (response) {
                 swaggestTest.assert(test.response, response);
               });
           });
@@ -89,5 +95,7 @@ describe('test api calls', function () {
   }
 });
 ```
+
+In fact, that's exactly how our command line tool `flat-white` does it. If you want to just run the tests and don't care about building them yourself, simply run `bin/flat-white swagger.json` and it'll do all of the work for you.
 
 WOOHOO! Automated tests generated using the swagger spec. Go you!

--- a/bin/flat-white
+++ b/bin/flat-white
@@ -2,7 +2,7 @@
 
 var fs = require('fs')
   , path = require('path')
-  , request = require('request');
+  , preq = require('preq');
 
 var swaggestTest = require(__dirname + '/../lib/swaggest-test');
 var usageStr = "USAGE: flat-white [swagger.json]";
@@ -20,13 +20,16 @@ function main() {
 				describe(describeStr, function () {
 					tests[route][method].forEach(function (test) {
 						it(test.description, function () {
-							return request[test.request.method]({
+							return preq[test.request.method]({
 								uri: test.request.uri,
 								query: test.request.query,
 								body: test.request.body,
-								headers: test.request.headers}, function (err, response) {
-									swaggestTest.assert(test.response, response);
-								});
+								headers: test.request.headers})
+							.then(function (response) {
+								swaggestTest.assert(test.response, response);
+							}, function (response) {
+								swaggestTest.assert(test.response, response);
+							});
 						});
 					});
 				});

--- a/bin/flat-white
+++ b/bin/flat-white
@@ -1,0 +1,38 @@
+#!/usr/bin/env mocha
+
+var fs = require('fs')
+  , path = require('path')
+  , request = require('request');
+
+var swaggestTest = require(__dirname + '/../lib/swaggest-test');
+var usageStr = "USAGE: flat-white [swagger.json]";
+
+function main() {
+  if (process.argv.length !== 4) return console.log(usageStr);
+  var swaggerFile = path.normalize(process.argv[3]);
+  describe('testing your swagger api using ' + swaggerFile, function () {
+		var spec = JSON.parse(fs.readFileSync(swaggerFile));
+		var tests = swaggestTest.parse(spec);
+
+		for (var route in tests) {
+			for (var method in tests[route]) {
+				var describeStr = 'Testing ' + method + ' ' + route;
+				describe(describeStr, function () {
+					tests[route][method].forEach(function (test) {
+						it(test.description, function () {
+							return request[test.request.method]({
+								uri: test.request.uri,
+								query: test.request.query,
+								body: test.request.body,
+								headers: test.request.headers}, function (err, response) {
+									swaggestTest.assert(test.response, response);
+								});
+						});
+					});
+				});
+			}
+		}
+  });
+}
+
+main();

--- a/lib/swaggest-test.js
+++ b/lib/swaggest-test.js
@@ -93,7 +93,9 @@ function parseTest(host, uri, method, methodParams, test) {
   return {
     description: test.description || method + ' ' + uri,
     request: request,
-    response: status
+    response: {
+      status: status
+    }
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "better swagger tests",
   "main": "swaggest-test.js",
   "dependencies": {
-    "uri-templates": "^0.2.0",
-    "chai": "^3.5.0"
+    "chai": "^3.5.0",
+    "mocha": "^2.5.3",
+    "request": "^2.72.0",
+    "uri-templates": "^0.2.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "chai": "^3.5.0",
     "mocha": "^2.5.3",
-    "request": "^2.72.0",
+    "preq": "^0.4.10",
     "uri-templates": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
you can now run `bin/flat-white swagger.json` and get back the results of your tests

Also, I updated the README and switched us back to using preq instead of requests, as requests was giving us lots of problems.