### PR TITLE
add support for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The `x-test` section should look something like this:
   x-test:
     - description: Return 50 dogs/cats
       request:
+        headers:
+          content-type: application/json
         parameters:
           tags:
             - dogs

--- a/lib/swaggest-test.js
+++ b/lib/swaggest-test.js
@@ -27,9 +27,10 @@ function parseParameters(testParams, methodParams) {
     path: {},
     query: {},
     body: {},
+    header: {},
     invalid: {}
   };
-  var methodParams = expandParameters(methodParams);
+  methodParams = expandParameters(methodParams);
 
   for (var key in testParams) {
     if (methodParams[key]) {
@@ -40,6 +41,9 @@ function parseParameters(testParams, methodParams) {
           break;
         case 'query':
           ret.query[key] = testParams[key];
+          break;
+        case 'header':
+          ret.header[key] = testParams[key];
           break;
         default:
           ret.invalid[key] = testParams[key];
@@ -57,6 +61,7 @@ function parseParameters(testParams, methodParams) {
 
   if (isEmpty(ret.body)) ret.body = null;
   if (isEmpty(ret.query)) ret.query = null;
+  if (isEmpty(ret.header)) ret.header = null;
 
   return ret;
 };
@@ -77,15 +82,24 @@ function parseTest(host, uri, method, methodParams, test) {
   request.path = parameters.path;
   request.query = parameters.query;
   request.body = parameters.body
-  request.headers = test.headers;
+  request.headers = test.request.headers;
 
+  //parameter headers override static headers
+  //if there's a conflict
+  if (parameters.header) {
+    if (!request.headers) request.headers = {};
+    for (var header in parameters.header) {
+      request.headers[header] = parameters.header[header];
+    }
+  }
+
+  //preq's body parser requires a content-type
   if (request.body) {
     if (!request.headers) request.headers = {};
     if (!request.headers['content-type']) {
       request.headers['content-type'] = 'application/json';
     }
   }
-
 
   request.method = method;
   request.uri = 'http://' + host + fullUri;
@@ -126,13 +140,15 @@ exports.parse = function(spec) {
     }
   }
 
-  console.log('Total routes:', totalRoutes);
-  console.log('Routes tested:', routesTested);
   return tests;
 }
 
 exports.assert = function(expected, actual) {
   if (expected.status) {
     assert.equal(expected.status, actual.status);
+  }
+
+  if (expected.headers) {
+    assert.equal(expected.headers, actual.headers);
   }
 }

--- a/tests/swagger.json
+++ b/tests/swagger.json
@@ -237,6 +237,42 @@
                     }
                 ]
             }
+        },
+        "/pets/feed": {
+            "get": {
+                "description": "feed a pet!",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "header",
+                        "description": "ID of the pet to feed",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet fed"
+                    }
+                },
+                "x-test": [
+                    {
+                        "description": "Feed a pet",
+                        "request": {
+                            "headers": {
+                                "content-type": "application/json"
+                            },
+                            "parameters": {
+                                "id": 101
+                            }
+                        },
+                        "response": {
+                            "200": null
+                        }
+                    }
+                ]
+            }
         }
     },
     "definitions": {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -5,15 +5,14 @@ var swaggestTest = require('../lib/swaggest-test');
 var assert = require('chai').assert;
 
 describe('test generation', function () {
-
   var testDir = __dirname;
   var buffer  = fs.readFileSync(testDir + '/swagger.json');
   var spec    = JSON.parse(buffer);
 
   var tests = swaggestTest.parse(spec);
 
-  it('has 2 routes', function () {
-    assert.equal(Object.keys(tests).length, 2);
+  it('has 3 routes', function () {
+    assert.equal(Object.keys(tests).length, 3);
   });
 
   it('test GET w/ query params on dogs/cats', function () {
@@ -33,75 +32,128 @@ describe('test generation', function () {
          method: 'get',
          uri: 'http://petstore.swagger.io/pets'
        },
-       response: 200
+       response: {
+         status: 200
+       }
      });
   });
 
   it('test GET w/ no params', function() {
     assert.deepEqual(tests['/pets'].get[1], {
-			description: 'Return E V E R Y T H I N G',
-			request: {
-				path: null,
-				query: null,
-				body: null,
+      description: 'Return E V E R Y T H I N G',
+      request: {
+        path: null,
+        query: null,
+        body: null,
         headers: undefined,
-				method: 'get',
-				uri: 'http://petstore.swagger.io/pets'
-			},
-			response: 200
-		});
+        method: 'get',
+        uri: 'http://petstore.swagger.io/pets'
+      },
+      response: {
+        status: 200
+      }
+    });
   });
 
   it('test POST', function() {
     assert.deepEqual(tests['/pets'].post[0], {
-			description: 'Add a new pet',
-			request: {
-				path: {},
-				query: null,
-				body: {
-					name: 'garythesnail'
-				},
-				headers: {
-					'content-type': 'application/json'
-				},
-				method: 'post',
-				uri: 'http://petstore.swagger.io/pets'
-			},
-			response: 200
-		});
+      description: 'Add a new pet',
+      request: {
+        path: {},
+        query: null,
+        body: {
+          name: 'garythesnail'
+        },
+        headers: {
+          'content-type': 'application/json'
+        },
+        method: 'post',
+        uri: 'http://petstore.swagger.io/pets'
+      },
+      response: {
+        status: 200
+      }
+    });
   });
 
   it('test another GET with a uri param', function() {
-		assert.deepEqual(tests['/pets/{id}'].get[0], {
-			description: 'Return a pet',
-			request: {
-				path: {
-					id: 101
-				},
+    assert.deepEqual(tests['/pets/{id}'].get[0], {
+      description: 'Return a pet',
+      request: {
+        path: {
+          id: 101
+        },
         headers: undefined,
-				query: null,
-				body: null,
-				method: 'get',
-				uri: 'http://petstore.swagger.io/pets/101'
-			},
-			response: 200
-		});
+        query: null,
+        body: null,
+        method: 'get',
+        uri: 'http://petstore.swagger.io/pets/101'
+      },
+      response: {
+        status: 200
+      }
+    });
   });
 
   it('test DELETE', function() {
     assert.deepEqual(tests['/pets/{id}']['delete'][0], {
-			description: 'Delete a pet',
-			request: {
-				path: {
-					id: 101
-				},
+      description: 'Delete a pet',
+      request: {
+        path: {
+          id: 101
+        },
         headers: undefined,
-				query: null,
-				body: null,
-				method: 'delete',
-				uri: 'http://petstore.swagger.io/pets/101'
-			},
-			response: 204
-		});
+        query: null,
+        body: null,
+        method: 'delete',
+        uri: 'http://petstore.swagger.io/pets/101'
+      },
+      response: {
+        status: 204
+      }
+    });
+  });
+
+  it('test with headers', function() {
+    assert.deepEqual(tests['/pets/feed']['get'][0], {
+      description: "Feed a pet",
+      request: {
+        path: {},
+        query: null,
+        body: null,
+        headers: {
+          id: 101,
+          'content-type': 'application/json'
+        },
+        method: "get",
+        uri: "http://petstore.swagger.io/pets/feed"
+      },
+      response: {
+        status: 200
+      }
+    });
+  });
+});
+
+describe('assertion functionality', function() {
+  it('simple status test', function() {
+    swaggestTest.assert({status: 200}, {status: 200});
+  });
+
+  var headerReq = {
+    status: 200,
+    headers: {
+      'content-type': 'application/json'
+    }
+  };
+
+  it('full response test', function() {
+    swaggestTest.assert(headerReq, headerReq);
+  });
+
+  delete headerReq.status;
+
+  it('header only test', function() {
+    swaggestTest.assert(headerReq, headerReq);
   });
 });


### PR DESCRIPTION
headers are now supported as parameters and also a "headers" field in
the request.

Closes #2 