### PR TITLE
Definitions/references in parameters is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The `x-test` section should look something like this:
 
 Note that parameters are simply given a value, the type (body, query, path) is grabbed from the API specification, so you don't have to worry about specifying that. At the moment, swaggest-test only has the ability to check the response code of the response, but will very soon be able to build more complete checks for responses. The description is a description that you will be able to access when it comes time to run your test, so it's good to know what's going on.
 
+Using `$ref` in parameters e.g. `- $ref: '#/parameters/test'` is allowed, as well as using `$ref` in the body schema, like `schema: $ref: '#/parameters/test'`.
+
 Also important to note that parameters that have a value starting with '$' are variables. You can pass these to swaggest-test and they will get filled in before the tests are generated.
 
 Once your swagger file is setup, export it into .json and you can use it for the tool and the library!

--- a/lib/swaggest-test.js
+++ b/lib/swaggest-test.js
@@ -9,26 +9,50 @@ function isEmpty(obj) {
   return (Object.keys(obj).length === 0 && obj.constructor === Object);
 };
 
-function swag(host, uri, method, methodParams, test, variables) {
+function swag(host, uri, method, methodParams, test, variables, spec) {
   this.host = host;
   this.uri = uri;
   this.method = method;
   this.methodParams = methodParams;
   this.test = test;
   this.variables = variables;
+  this.spec = spec;
 
   //guard
   if (!this.test.request) this.test.request = {};
   this.testParams = test.request.parameters;
 }
 
+function getDef(spec, ref) {
+  var def = spec;
+  ref = ref.substring(2).split('/');
+  ref.forEach(function(elem) {
+    def = def[elem];
+  });
+  return def;
+}
+
 swag.prototype.expandParameters = function() {
   var params = {};
+  var methodParams = this.methodParams;
+  var spec = this.spec;
 
-  this.methodParams.forEach(function (param) {
-    //body isn't always named body
-    if (param['in'] === 'body') params.body = param;
-    else params[param.name] = param;
+  methodParams.forEach(function (param) {
+    //body isn't always named body, simple name replace
+    if (param['in'] === 'body' && !param.schema['$ref'])
+      return params.body = param;
+    //same thing but fill in the definition
+    if (param['in'] === 'body') {
+      params.body = {};
+      return params.body.schema = getDef(spec, param.schema['$ref']);
+    }
+    //fill a definition
+    if (param['$ref']) {
+      var def = getDef(spec, param['$ref']);
+      return params[def.name] = def;
+    }
+    //simple param
+    return params[param.name] = param;
   });
 
   this.methodParams = params;
@@ -158,6 +182,8 @@ exports.parse = function(spec, variables) {
 
   var host = spec.host || 'localhost';
 
+  var defs = spec.definitions;
+
   var paths = spec.paths || {};
   for (var uri in paths) {
     var path = spec.paths[uri];
@@ -170,7 +196,7 @@ exports.parse = function(spec, variables) {
       if (pathTests) {
         routesTested++;
         pathTests.forEach(function (test) {
-          var swaggy = new swag(host, uri, method, methodParams, test, variables);
+          var swaggy = new swag(host, uri, method, methodParams, test, variables, spec);
           testSet.push(swaggy.parseTest());
         });
       }

--- a/tests/swagger.json
+++ b/tests/swagger.json
@@ -113,12 +113,7 @@
                         "description": "Pet to add to the store",
                         "required": true,
                         "schema": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
+                            "$ref": "#/definitions/addPet"
                         }
                     }
                 ],
@@ -243,12 +238,7 @@
                 "description": "feed a pet!",
                 "parameters": [
                     {
-                        "name": "id",
-                        "in": "header",
-                        "description": "ID of the pet to feed",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int64"
+                        "$ref": "#/parameters/headerId"
                     },
                     {
                         "name": "token",
@@ -303,6 +293,17 @@
                 }
             }
         },
+        "addPet": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "errorModel": {
             "type": "object",
             "required": [
@@ -318,6 +319,16 @@
                     "type": "string"
                 }
             }
+        }
+    },
+    "parameters": {
+        "headerId": {
+            "name": "id",
+            "in": "header",
+            "description": "ID of the pet to feed",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
         }
     }
 }


### PR DESCRIPTION
* defining a single parameter is now supported, by simply doing `- $ref: '#/parameters/ourParam` in the request parameters section of your swagger file
* defining the body schema using by simply using `$ref` is supported.